### PR TITLE
Add the total balance to the dashboard

### DIFF
--- a/client/src/components/Other/GroupComponent.js
+++ b/client/src/components/Other/GroupComponent.js
@@ -13,11 +13,11 @@ const GroupComponent = ({
   let base_currency = 0;
 
   if (account.data.balanceData) {
-    amount = Number(account.data.balanceData.amount).toFixed(2);
+    amount = Number(account.data.balanceData.amount);
     currency = account.data.balanceData.currency;
     base_currency = account.data.balanceData.base_currency;
   } else {
-    amount = Number(account.data.quantity).toFixed(2);
+    amount = Number(account.data.quantity);
     currency = account.data.symbol;
     base_currency = account.data.base_currency;
   }
@@ -47,11 +47,17 @@ const GroupComponent = ({
               {type}: {base_currency} {baseSymbol}
             </p>
           )}
-        {(provider === "custom_assets" ||
-          provider === "binance" ||
-          provider === "coinbase") && (
+        {(provider === "custom_assets" || provider === "binance") && (
           <p>
-            {currency}: {amount}; {base_currency} {baseSymbol}
+            {currency}: {amount.toFixed(2)}; {base_currency} {baseSymbol}
+          </p>
+        )}
+        {provider === "coinbase" && (
+          <p
+            onClick={() => getTransactionsFunc(provider, account.id)}
+            className="has-transactions"
+          >
+            {currency}: {amount.toFixed(2)}; {base_currency} {baseSymbol}
           </p>
         )}
       </div>

--- a/client/src/components/Other/GroupsContainerComponent.js
+++ b/client/src/components/Other/GroupsContainerComponent.js
@@ -4,12 +4,16 @@ import HoldingComponent from "./HoldingComponent";
 
 const GroupsContainerComponent = ({
   data,
+  total,
   getTransactionsFunc,
   baseSymbol,
 }) => {
   let source;
   return (
     <div>
+      <h4>
+        Total balance: {total.toFixed(2)} {baseSymbol}
+      </h4>
       {Object.entries(data).map(([key, value]) => {
         source = key;
         return (

--- a/client/src/components/Pages/DashboardPage.js
+++ b/client/src/components/Pages/DashboardPage.js
@@ -18,6 +18,7 @@ const DashboardPage = () => {
   const [groups, setGroups] = useState({});
   const [transactions, setTransactions] = useState({});
   const [base, setBase] = useState("");
+  const [total, setTotal] = useState(0);
 
   const [loading, setLoading] = useState(false);
 
@@ -41,6 +42,10 @@ const DashboardPage = () => {
     await Promise.all([
       (async () => {
         const assets = await getAssets(token);
+        const total = assets.total;
+        delete assets.total;
+
+        setTotal(total);
         setGroups(assets);
       })(),
     ]);
@@ -83,6 +88,7 @@ const DashboardPage = () => {
             <GroupsContainerComponent
               baseSymbol={base}
               data={groups}
+              total={total}
               getTransactionsFunc={getAccountTransactions}
             />
           </div>

--- a/server/portfolio/portfolio/blueprints/api.py
+++ b/server/portfolio/portfolio/blueprints/api.py
@@ -48,7 +48,7 @@ async def get_assets():
 
         convert_assets_value_to_base_currency(user_data['base_currency'], balances, holdings)
         data = group_balances(balances, holdings)
-        cache_assets(data, user_data['user_identifier'])
+        cache_assets({key: value for (key, value) in data.items() if key != "total"}, user_data['user_identifier'])
 
     return jsonify(data), 200
 

--- a/server/portfolio/portfolio/utils/format.py
+++ b/server/portfolio/portfolio/utils/format.py
@@ -1,5 +1,6 @@
 def group_balances(balances: dict, holdings: dict):
     result = {}
+    total_balance = 0
     for provider, content in balances.items():
         for account, account_content in content['content'].items():
             name = account_content['providerName']
@@ -19,11 +20,13 @@ def group_balances(balances: dict, holdings: dict):
                     result[name]['accounts'] = [data]
                 
                 if account_content['balanceData'].get('base_currency'):
+                    total_balance += float(account_content['balanceData']['base_currency'])
                     if result[name].get('total'):
                         result[name]['total'] += account_content['balanceData']['base_currency']
                     else:
                         result[name]['total'] = account_content['balanceData']['base_currency']
             else:
+                total_balance += float(account_content['balanceData']['base_currency'])
                 result[name] = {'accounts': [data], 'total': account_content['balanceData']['base_currency']}
 
     for provider, content in {key:value for (key, value) in holdings.items() if key != "yodlee"}.items():
@@ -37,15 +40,19 @@ def group_balances(balances: dict, holdings: dict):
                     result[provider]['accounts'] = [data]
 
                 if asset_content.get('base_currency'):
+                    total_balance += float(asset_content['base_currency'])
                     if result[provider].get('total'):
                         result[provider]['total'] += asset_content['base_currency']
                     else:
                         result[provider]['total'] = asset_content['base_currency']
             else:
                 if asset_content.get('base_currency'):
+                    total_balance += float(asset_content['base_currency'])
                     result[provider] = {'accounts': [data], 'total': asset_content['base_currency']}
                 else:
                     result[provider] = {'accounts': [data], 'total': 0}
-    
+
+    result['total'] = total_balance
+
     return result
             


### PR DESCRIPTION
- fixes a bug in the dashboard where small amounts of cryptocurrencies(e.g 0.005 BTC) wouldn't render
- fixes a bug in the dashboard where the transactions couldn't be retrieved for Coinbase accounts
- adds a `total` field to the Portfolio response object on the `api/assets` endpoint
- adds a heading with the total balance

closes #235