### PR TITLE
Add functionality for getting all/ recent transactions

### DIFF
--- a/client/src/components/Other/GroupsContainerComponent.js
+++ b/client/src/components/Other/GroupsContainerComponent.js
@@ -44,6 +44,8 @@ const GroupsContainerComponent = ({
                         return (
                           <HoldingComponent
                             nest={false}
+                            account={account}
+                            getTransactionsFunc={getTransactionsFunc}
                             data={holding}
                             baseSymbol={baseSymbol}
                           />

--- a/client/src/components/Other/HoldingComponent.js
+++ b/client/src/components/Other/HoldingComponent.js
@@ -1,10 +1,19 @@
 import React from "react";
 
-const HoldingComponent = ({ data, baseSymbol, nest }) => {
+const HoldingComponent = ({
+  data,
+  baseSymbol,
+  nest,
+  account,
+  getTransactionsFunc,
+}) => {
   return (
     <div>
       {!nest && (
-        <p>
+        <p
+          onClick={() => getTransactionsFunc(account.provider, account.id)}
+          className="has-transactions"
+        >
           {data.symbol}: {data.quantity}; {data.base_currency.toFixed(2)}{" "}
           {baseSymbol}
         </p>

--- a/client/src/components/Other/RecentTransactionsContainerComponent.js
+++ b/client/src/components/Other/RecentTransactionsContainerComponent.js
@@ -1,0 +1,22 @@
+import React from "react";
+
+const RecentTransactionsContainerComponent = ({ data }) => {
+  return (
+    <div>
+      <ul>
+        {data.map((element) => {
+          return Object.values(element).map((value) => {
+            console.log(value);
+            return (
+              <li>
+                {value.amount.amount} {value.amount.currency}
+              </li>
+            );
+          });
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default RecentTransactionsContainerComponent;

--- a/client/src/components/Pages/DashboardPage.js
+++ b/client/src/components/Pages/DashboardPage.js
@@ -5,7 +5,11 @@ import { Redirect } from "react-router";
 import LogOutButton from "../Buttons/LogOutButton";
 import ProfileButton from "../Buttons/ProfileButton";
 
-import { getAssets, getTransactions } from "../../utils/portfolio";
+import {
+  getAssets,
+  getTransactions,
+  getAllRecentTransactions,
+} from "../../utils/portfolio";
 import { getUser } from "../../utils/account";
 
 import GroupsContainerComponent from "../Other/GroupsContainerComponent";
@@ -55,6 +59,15 @@ const DashboardPage = () => {
     setTransactions({ transactions });
     setLoading(false);
   };
+
+  const getRecentTransactions = async () => {
+    setLoading(true);
+    const token = await getAccessTokenSilently();
+    const transactions = await getAllRecentTransactions(token);
+    console.log(transactions);
+    setLoading(false);
+  };
+
   // fetch all data on first render
   useEffect(() => {
     getData();
@@ -76,6 +89,9 @@ const DashboardPage = () => {
         <h2>Hi, {user.name}, this is the dashboard</h2>
         <LogOutButton />
         <ProfileButton />
+        <button onClick={() => getRecentTransactions()}>
+          Recent transactions
+        </button>
 
         <div className="dashboard-container">
           <div className="container">

--- a/client/src/components/Pages/DashboardPage.js
+++ b/client/src/components/Pages/DashboardPage.js
@@ -25,7 +25,7 @@ const DashboardPage = () => {
   const [recentTransactions, setRecentTransactions] = useState([]);
   const [base, setBase] = useState("");
 
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   const { user, isAuthenticated, isLoading, getAccessTokenSilently } =
     useAuth0();
@@ -67,11 +67,8 @@ const DashboardPage = () => {
   };
 
   const getRecentTransactions = async () => {
-    setLoading(true);
     const token = await getAccessTokenSilently();
     const transactions = await getAllRecentTransactions(token);
-    console.log(transactions);
-    setLoading(false);
     return transactions.content;
   };
 

--- a/client/src/components/Pages/DashboardPage.js
+++ b/client/src/components/Pages/DashboardPage.js
@@ -14,6 +14,7 @@ import { getUser } from "../../utils/account";
 
 import GroupsContainerComponent from "../Other/GroupsContainerComponent";
 import TransactionsContainerComponent from "../Other/TransactionsContainerComponent";
+import RecentTransactionsContainerComponent from "../Other/RecentTransactionsContainerComponent";
 
 import "../../styles/dashboard.css";
 
@@ -21,6 +22,7 @@ import "../../styles/dashboard.css";
 const DashboardPage = () => {
   const [groups, setGroups] = useState({});
   const [transactions, setTransactions] = useState({});
+  const [recentTransactions, setRecentTransactions] = useState([]);
   const [base, setBase] = useState("");
 
   const [loading, setLoading] = useState(false);
@@ -47,6 +49,10 @@ const DashboardPage = () => {
         const assets = await getAssets(token);
         setGroups(assets);
       })(),
+      (async () => {
+        const transactions = await getRecentTransactions(token);
+        setRecentTransactions(transactions);
+      })(),
     ]);
 
     setLoading(false);
@@ -66,6 +72,7 @@ const DashboardPage = () => {
     const transactions = await getAllRecentTransactions(token);
     console.log(transactions);
     setLoading(false);
+    return transactions.content;
   };
 
   // fetch all data on first render
@@ -106,6 +113,11 @@ const DashboardPage = () => {
           <div className="container">
             <h1>Transactions</h1>
             <TransactionsContainerComponent data={transactions} />
+          </div>
+
+          <div className="container">
+            <h1>Recent Transactions</h1>
+            <RecentTransactionsContainerComponent data={recentTransactions} />
           </div>
         </div>
       </div>

--- a/client/src/components/Pages/DashboardPage.js
+++ b/client/src/components/Pages/DashboardPage.js
@@ -93,9 +93,6 @@ const DashboardPage = () => {
         <h2>Hi, {user.name}, this is the dashboard</h2>
         <LogOutButton />
         <ProfileButton />
-        <button onClick={() => getRecentTransactions()}>
-          Recent transactions
-        </button>
 
         <div className="dashboard-container">
           <div className="container">

--- a/client/src/utils/portfolio.js
+++ b/client/src/utils/portfolio.js
@@ -26,6 +26,7 @@ const getAllRecentTransactions = async (token) => {
     {
       headers: {
         Authorization: `Bearer ${token}`,
+        Recent: "True",
       },
     }
   );

--- a/client/src/utils/portfolio.js
+++ b/client/src/utils/portfolio.js
@@ -20,6 +20,19 @@ const getTransactions = async (token, provider, account) => {
   return response.json();
 };
 
+const getAllRecentTransactions = async (token) => {
+  const response = await fetch(
+    "http://localhost:5001/api/recent-transactions",
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+
+  return response.json();
+};
+
 const createCustomAsset = async (token, type, symbol, amount) => {
   const response = await fetch("http://localhost:5001/api/create-asset", {
     headers: {
@@ -33,4 +46,9 @@ const createCustomAsset = async (token, type, symbol, amount) => {
   return response.json();
 };
 
-export { getAssets, getTransactions, createCustomAsset };
+export {
+  getAssets,
+  getTransactions,
+  createCustomAsset,
+  getAllRecentTransactions,
+};

--- a/server/assets_v2/assets/blueprints/api.py
+++ b/server/assets_v2/assets/blueprints/api.py
@@ -91,8 +91,6 @@ async def get_recent_transactions():
                     tasks.append(asyncio.ensure_future(get_all_yodlee_transactions(yodlee_login_name, session=session)))
                 if nordigen_requisitions:
                     await get_all_nordigen_transactions(requisitions=nordigen_requisitions, session=session, tasks=tasks)
-                if coinbase_secret and coinbase_key:
-                    coinbase_transactions = get_all_coinbase_transactions(coinbase_key, coinbase_secret)
 
                 responses = await asyncio.gather(*tasks)
                 for response in responses:
@@ -105,10 +103,13 @@ async def get_recent_transactions():
                         else:
                             continue
                     result.append(response)
-                
-                if coinbase_transactions:
-                    for transaction in coinbase_transactions:
-                        result.append(transaction)
+
+            if coinbase_secret and coinbase_key:
+                coinbase_transactions = get_all_coinbase_transactions(coinbase_key, coinbase_secret)
+            
+            if coinbase_transactions:
+                for transaction in coinbase_transactions:
+                    result.append(transaction)
             
             for element in result:
                 if type(element) is list:

--- a/server/assets_v2/assets/blueprints/api.py
+++ b/server/assets_v2/assets/blueprints/api.py
@@ -14,6 +14,7 @@ from ..utils.nordigen import get_single_account_balance as get_nordigen_balance
 from ..utils.binance_api import get_balances as get_binance_holdings
 from ..utils.coinbase_api import get_account_balances as get_coinbase_holdings
 from ..utils.coinbase_api import get_transactions as get_coinbase_transactions
+from ..utils.coinbase_api import get_all_transactions as get_all_coinbase_transactions
 from ..utils.custom_assets_api import get_holdings as get_custom_assets_holdings
 
 bp = Blueprint('api', __name__)
@@ -75,34 +76,50 @@ async def get_transactions():
 @bp.route('/recent-transactions', methods=(['GET']))
 async def get_recent_transactions():
     nordigen_requisitions = json.loads(request.headers.get('nordigen_requisitions'))
+    yodlee_login_name = request.headers.get('yodlee_loginName')
+    coinbase_key = request.headers.get('coinbase_key')
+    coinbase_secret = request.headers.get('coinbase_secret')
+
     result = []
     final = []
-    
-    try:
-        async with aiohttp.ClientSession() as session:
-            tasks = []
-            tasks.append(asyncio.ensure_future(get_all_yodlee_transactions(request.headers.get('yodlee_loginName'), session=session)))
-            await get_all_nordigen_transactions(requisitions=nordigen_requisitions, session=session, tasks=tasks)
 
-            responses = await asyncio.gather(*tasks)
-            for response in responses:
-                if type(response) is dict:
-                    if not response.get('status') == "failed":
-                        transactions = response.get('content')
-                        for source in transactions:
-                            for transaction in source:
-                                result.append(transaction)
-                    else:
-                        continue
-                result.append(response)
+    if nordigen_requisitions or yodlee_login_name or (coinbase_secret and coinbase_key):
+        try:
+            async with aiohttp.ClientSession() as session:
+                tasks = []
+                if yodlee_login_name:
+                    tasks.append(asyncio.ensure_future(get_all_yodlee_transactions(yodlee_login_name, session=session)))
+                if nordigen_requisitions:
+                    await get_all_nordigen_transactions(requisitions=nordigen_requisitions, session=session, tasks=tasks)
+                if coinbase_secret and coinbase_key:
+                    coinbase_transactions = get_all_coinbase_transactions(coinbase_key, coinbase_secret)
+
+                responses = await asyncio.gather(*tasks)
+                for response in responses:
+                    if type(response) is dict:
+                        if not response.get('status') == "failed":
+                            transactions = response.get('content')
+                            for source in transactions:
+                                for transaction in source:
+                                    result.append(transaction)
+                        else:
+                            continue
+                    result.append(response)
+                
+                if coinbase_transactions:
+                    for transaction in coinbase_transactions:
+                        result.append(transaction)
+            
+            for element in result:
+                if type(element) is list:
+                    for transaction in element:
+                        final.append(transaction)
+                elif type(element) is dict:
+                    final.append(element)
+        except Exception as e:
+            print(str(e))
+            return None
         
-        for element in result:
-            if type(element) is list:
-                for transaction in element:
-                    final.append(transaction)
-            elif type(element) is dict:
-                final.append(element)
-    except Exception as e:
-        return {'status': 'failed', 'content': str(e)}
-
-    return jsonify({'status': 'success', 'content': final})
+        return jsonify({'status': 'success', 'content': final}) 
+    else: 
+        return None

--- a/server/assets_v2/assets/blueprints/api.py
+++ b/server/assets_v2/assets/blueprints/api.py
@@ -76,6 +76,7 @@ async def get_transactions():
 async def get_recent_transactions():
     nordigen_requisitions = json.loads(request.headers.get('nordigen_requisitions'))
     result = []
+    final = []
     async with aiohttp.ClientSession() as session:
         tasks = []
         tasks.append(asyncio.ensure_future(get_all_yodlee_transactions(request.headers.get('yodlee_loginName'), session=session)))
@@ -83,6 +84,21 @@ async def get_recent_transactions():
 
         responses = await asyncio.gather(*tasks)
         for response in responses:
+            if type(response) is dict:
+                if not response.get('status') == "failed":
+                    transactions = response.get('content')
+                    for source in transactions:
+                        for transaction in source:
+                            result.append(transaction)
+                else:
+                    continue
             result.append(response)
+    
+    for element in result:
+        if type(element) is list:
+            for transaction in element:
+                final.append(transaction)
+        elif type(element) is dict:
+            final.append(element)
 
-    return jsonify(result)
+    return jsonify(final)

--- a/server/assets_v2/assets/blueprints/api.py
+++ b/server/assets_v2/assets/blueprints/api.py
@@ -6,6 +6,7 @@ import aiohttp, asyncio
 from ..utils.yodlee_api import get_balances as get_yodlee_balances
 from ..utils.yodlee_api import get_holdings as get_yodlee_holdings
 from ..utils.yodlee_api import get_transactions as get_yodlee_transactions
+from ..utils.yodlee_api import get_all_transactions as get_all_yodlee_transactions
 from ..utils.nordigen import get_all_accounts_balances as get_nordigen_balances
 from ..utils.nordigen import get_account_transactions as get_nordigen_transactions
 from ..utils.nordigen import get_single_account_balance as get_nordigen_balance
@@ -69,3 +70,8 @@ async def get_transactions():
             return {'status': 'failed', 'content': 'provider is not valid or missing'}
 
     return jsonify(results)
+
+@bp.route('/recent-transactions', methods=(['GET']))
+async def get_recent_transactions():
+    yodlee_transactions = get_all_yodlee_transactions(request.headers.get('yodlee_loginName'))
+    return yodlee_transactions

--- a/server/assets_v2/assets/utils/nordigen.py
+++ b/server/assets_v2/assets/utils/nordigen.py
@@ -1,7 +1,4 @@
-import asyncio
-import os
-
-import requests
+import asyncio, os, requests
 
 SECRET_ID = os.environ.get('ASSETS_NORDIGEN_ID')
 SECRET_KEY = os.environ.get('ASSETS_NORDIGEN_KEY')
@@ -233,7 +230,7 @@ async def get_account_transactions(account, session):
     if response['status'] != 'success':
         return response
 
-    headers = {'Authorization': f'Bearer {response["content"]}'}
+    headers = {'Authorization': f"Bearer {response['content']}"}
 
     bank_name = await get_bank_name(account, session, headers)
     if not bank_name:
@@ -259,6 +256,33 @@ async def get_account_transactions(account, session):
     # return saved data
     return {'status': 'success', 'content': data}
 
+async def get_all_transactions(requisitions, session, tasks):
+    response = get_access_token()
+
+    if response['status'] != 'success':
+        return response
+
+    headers = {'Authorization': f"Bearer {response['content']}"}
+    
+    async def get_transactions(session, account):
+        async with session.get(URL + f'accounts/{account}/transactions/',
+                               headers=headers) as response:
+            awaited = await response.json()
+            return awaited.get('transactions').get('booked')
+
+    for requisition in requisitions:
+        # get user bank accounts from requisition
+        accounts = await get_bank_accounts(requisition, session, headers)
+
+        # check requisition validation and check if user has bank accounts
+        if not accounts[1]:
+            # return error message
+            return accounts[0]
+
+        # if requisition is valid and user has bank accounts we take his accounts
+        accounts = accounts[0]['content']
+        for account in accounts:
+            tasks.append(asyncio.ensure_future(get_transactions(session, account)))
 
 async def get_all_accounts_balances(requisitions, session, tasks):
     if not requisitions:

--- a/server/assets_v2/assets/utils/nordigen.py
+++ b/server/assets_v2/assets/utils/nordigen.py
@@ -275,11 +275,13 @@ async def get_all_transactions(requisitions, session, tasks):
                 result.append(transaction_data)
             return result
 
-
+    requisition_tasks = []
     for requisition in requisitions:
         # get user bank accounts from requisition
-        accounts = await get_bank_accounts(requisition, session, headers)
-
+        requisition_tasks.append(asyncio.ensure_future(get_bank_accounts(requisition, session, headers)))
+        
+    responses = await asyncio.gather(*requisition_tasks)
+    for accounts in responses:
         if not accounts[1]:
             continue
 

--- a/server/assets_v2/assets/utils/nordigen.py
+++ b/server/assets_v2/assets/utils/nordigen.py
@@ -268,7 +268,13 @@ async def get_all_transactions(requisitions, session, tasks):
         async with session.get(URL + f'accounts/{account}/transactions/',
                                headers=headers) as response:
             awaited = await response.json()
-            return awaited.get('transactions').get('booked')
+            data = awaited.get('transactions').get('booked')
+            result = []
+            for transaction in data:
+                transaction_data = {transaction['transactionId']: transaction['transactionAmount']}
+                result.append(transaction_data)
+            return result
+
 
     for requisition in requisitions:
         # get user bank accounts from requisition

--- a/server/assets_v2/assets/utils/nordigen.py
+++ b/server/assets_v2/assets/utils/nordigen.py
@@ -271,7 +271,7 @@ async def get_all_transactions(requisitions, session, tasks):
             data = awaited.get('transactions').get('booked')
             result = []
             for transaction in data:
-                transaction_data = {transaction['transactionId']: transaction['transactionAmount']}
+                transaction_data = {transaction['transactionId']: {"amount": transaction['transactionAmount'], "date": transaction['bookingDate'], "type": "bank"}}
                 result.append(transaction_data)
             return result
 

--- a/server/assets_v2/assets/utils/nordigen.py
+++ b/server/assets_v2/assets/utils/nordigen.py
@@ -280,12 +280,9 @@ async def get_all_transactions(requisitions, session, tasks):
         # get user bank accounts from requisition
         accounts = await get_bank_accounts(requisition, session, headers)
 
-        # check requisition validation and check if user has bank accounts
         if not accounts[1]:
-            # return error message
-            return accounts[0]
+            continue
 
-        # if requisition is valid and user has bank accounts we take his accounts
         accounts = accounts[0]['content']
         for account in accounts:
             tasks.append(asyncio.ensure_future(get_transactions(session, account)))

--- a/server/assets_v2/assets/utils/yodlee_api.py
+++ b/server/assets_v2/assets/utils/yodlee_api.py
@@ -245,7 +245,7 @@ async def get_transactions(loginName, session, account):
     else:
         return access_token
 
-def get_all_transactions(loginName):
+async def get_all_transactions(loginName, session):
     if not loginName: return {'status': 'failed', 'content': 'Error: no Yodlee loginName was provided'}
     # try to obtain a token and return an error if it fails
     access_token = get_access_token(loginName)
@@ -255,8 +255,9 @@ def get_all_transactions(loginName):
             headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + access_token['content']}
 
             # send the request and save the balance for each account
-            response = requests.get(URL + 'transactions', headers=headers).json()
-            return format_transactions_response(response)
+            async with session.get(URL + 'transactions', headers=headers, ssl=False) as resp:
+                awaited = await resp.json()
+                return format_transactions_response(awaited)
 
         else:
             response = TRANSACTIONS_MOCK_DATA

--- a/server/assets_v2/assets/utils/yodlee_api.py
+++ b/server/assets_v2/assets/utils/yodlee_api.py
@@ -245,6 +245,25 @@ async def get_transactions(loginName, session, account):
     else:
         return access_token
 
+def get_all_transactions(loginName):
+    if not loginName: return {'status': 'failed', 'content': 'Error: no Yodlee loginName was provided'}
+    # try to obtain a token and return an error if it fails
+    access_token = get_access_token(loginName)
+    if access_token['status'] == 'success':
+        if USE_MOCK != 'True':
+            # set up header data and query parameters for the request
+            headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + access_token['content']}
+
+            # send the request and save the balance for each account
+            response = requests.get(URL + 'transactions', headers=headers).json()
+            return format_transactions_response(response)
+
+        else:
+            response = TRANSACTIONS_MOCK_DATA
+            return format_transactions_response(response)
+        
+    else:
+        return access_token
 
 async def get_holdings(loginName, session):
     if not loginName: return {'status': 'failed', 'content': 'Error: no Yodlee loginName was provided'}

--- a/server/assets_v2/assets/utils/yodlee_api.py
+++ b/server/assets_v2/assets/utils/yodlee_api.py
@@ -231,7 +231,7 @@ async def get_transactions(loginName, session, account):
         if USE_MOCK != 'True':
             # set up header data and query parameters for the request
             headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + access_token['content']}
-            params = {'top': 10, 'fromDate': '2013-12-12', 'accountId': account}
+            params = {'top': 10, 'accountId': account}
 
             # send the request and save the balance for each account
             async with session.get(URL + 'transactions', headers=headers, params=params, ssl=False) as resp:

--- a/server/assets_v2/assets/utils/yodlee_api.py
+++ b/server/assets_v2/assets/utils/yodlee_api.py
@@ -157,7 +157,7 @@ def format_holdings_response(response):
         return {'status': 'failed', 'content': f"Error: Unknown"}
 
 
-def format_transactions_response(response):
+def format_transactions_response(response, recent=False):
     try:
         transactions = response["transaction"]
     except:
@@ -176,7 +176,10 @@ def format_transactions_response(response):
 
         #    add only the completed transactions
         if transaction['status'] == 'POSTED':
-            transaction_data[source][transaction["id"]] = transaction['amount']
+            if not recent:
+                transaction_data[source][transaction["id"]] = transaction['amount']
+            else:
+                transaction_data[source][transaction["id"]] = {'amount': transaction['amount'], 'date': transaction['date'], 'type': transaction['CONTAINER']}
 
     data = transaction_data
 
@@ -257,11 +260,11 @@ async def get_all_transactions(loginName, session):
             # send the request and save the balance for each account
             async with session.get(URL + 'transactions', headers=headers, ssl=False) as resp:
                 awaited = await resp.json()
-                return format_transactions_response(awaited)
+                return format_transactions_response(awaited, recent=True)
 
         else:
             response = TRANSACTIONS_MOCK_DATA
-            return format_transactions_response(response)
+            return format_transactions_response(response, recent=True)
         
     else:
         return access_token

--- a/server/assets_v2/requirements.txt
+++ b/server/assets_v2/requirements.txt
@@ -16,6 +16,7 @@ cryptography==35.0.0
 Flask==2.0.2
 Flask-Cors==3.0.10
 hyperlink==21.0.0
+httpx==0.21.1
 idna==2.10
 incremental==21.3.0
 itsdangerous==2.0.1

--- a/server/portfolio/portfolio/blueprints/api.py
+++ b/server/portfolio/portfolio/blueprints/api.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import json
 
 from flask import Blueprint, jsonify, request
@@ -100,8 +101,10 @@ def get_recent_transactions():
     response = get_assets_recent_transactions(headers=headers)
     convert_transactions_currency_to_base_currency(user_data['base_currency'], response, recent=True)
 
+    response['content'].sort(key=lambda x: datetime.strptime(list(x.values())[0]['date'], "%Y-%m-%d"), reverse=True)
+
     if recent == 'True':
-        response = response["content"][:6]
+        response = {"status": "success", "content": response["content"][:6]}
 
     return jsonify(response)
 

--- a/server/portfolio/portfolio/blueprints/api.py
+++ b/server/portfolio/portfolio/blueprints/api.py
@@ -85,6 +85,7 @@ def get_account_transactions():
 def get_recent_transactions():
     # check if a token was passed in the Authorization header
     received_token = request.headers.get('Authorization')
+    recent = request.headers.get('Recent')
     validated_token = validate_auth_header(received_token)
 
     if not validated_token[0]:
@@ -97,6 +98,10 @@ def get_recent_transactions():
     headers = {'yodlee_loginName': user_data['user_identifier'], 'nordigen_requisitions': all_requisitions}
 
     response = get_assets_recent_transactions(headers=headers)
+    convert_transactions_currency_to_base_currency(user_data['base_currency'], response, recent=True)
+
+    if recent == 'True':
+        response = response["content"][:6]
 
     return jsonify(response)
 

--- a/server/portfolio/portfolio/blueprints/api.py
+++ b/server/portfolio/portfolio/blueprints/api.py
@@ -96,15 +96,18 @@ def get_recent_transactions():
     all_requisitions = user_data['nordigenrequisition_set']
     all_requisitions = json.dumps([el['requisition_id'] for el in all_requisitions])
 
-    headers = {'yodlee_loginName': user_data['user_identifier'], 'nordigen_requisitions': all_requisitions}
+    headers = {'yodlee_loginName': user_data['user_identifier'], 'nordigen_requisitions': all_requisitions, 'coinbase_key': user_data['coinbase_api_key'], 'coinbase_secret': user_data['coinbase_api_secret']}
 
     response = get_assets_recent_transactions(headers=headers)
-    convert_transactions_currency_to_base_currency(user_data['base_currency'], response, recent=True)
+    if response:
+        convert_transactions_currency_to_base_currency(user_data['base_currency'], response, recent=True)
 
-    response['content'].sort(key=lambda x: datetime.strptime(list(x.values())[0]['date'], "%Y-%m-%d"), reverse=True)
+        response['content'].sort(key=lambda x: datetime.strptime(list(x.values())[0]['date'], "%Y-%m-%d"), reverse=True)
 
-    if recent == 'True':
-        response = {"status": "success", "content": response["content"][:6]}
+        if recent == 'True':
+            response = {"status": "success", "content": response["content"][:6]}
+    else:
+        response = None
 
     return jsonify(response)
 

--- a/server/portfolio/portfolio/utils/assets.py
+++ b/server/portfolio/portfolio/utils/assets.py
@@ -8,11 +8,14 @@ async def get_balances(headers, session):
     async with session.get(URL + "balances", headers=headers, ssl=False) as res:
         return await res.json()
 
-
-
-# fetch all transactions using Assets
+# fetch transactions for a specific account 
 def get_transactions(headers):
     res = requests.get(URL + "transactions", headers=headers)
+    return res.json()
+
+# fetch the recent transactions
+def get_assets_recent_transactions(headers):
+    res = requests.get(URL + "recent-transactions", headers=headers)
     return res.json()
 
 # fetch all holdings using Assets

--- a/server/portfolio/portfolio/utils/reference.py
+++ b/server/portfolio/portfolio/utils/reference.py
@@ -46,19 +46,33 @@ def convert_assets_value_to_base_currency(base, balances, holdings):
                     asset["monitor_currency"] = usd_currency / float(currency_prices_gbp["USD"])
 
 
-def convert_transactions_currency_to_base_currency(base, transactions):
+def convert_transactions_currency_to_base_currency(base, transactions, recent=False):
     if transactions["status"] != "failed":
         currency_prices = get_currencies_prices(base)
         crypto_prices = get_crypto_prices()
 
-        for transaction in transactions["content"].values():
-            for amount in transaction.values():
-                if currency_prices.get(amount["currency"]):
-                    amount["amount"] = float(amount["amount"]) / currency_prices[amount["currency"]]
-                    amount["currency"] = base
+        if not recent:
+            for transaction in transactions["content"].values():
+                    for amount in transaction.values():
+                        if currency_prices.get(amount["currency"]):
+                            amount["amount"] = float(amount["amount"]) / currency_prices[amount["currency"]]
+                            amount["currency"] = base
 
-                else:
-                    if crypto_prices.get(amount["currency"]):
-                        usd_currency = float(crypto_prices[amount["currency"]]) * float(amount["amount"])
-                        amount["amount"] = usd_currency / float(currency_prices["USD"])
+                        else:
+                            if crypto_prices.get(amount["currency"]):
+                                usd_currency = float(crypto_prices[amount["currency"]]) * float(amount["amount"])
+                                amount["amount"] = usd_currency / float(currency_prices["USD"])
+                                amount["currency"] = base
+        else:
+            for transaction in transactions['content']:
+                for data in transaction.values():
+                    amount = data["amount"]
+                    if currency_prices.get(amount["currency"]):
+                        amount["amount"] = float(amount["amount"]) / currency_prices[amount["currency"]]
                         amount["currency"] = base
+
+                    else:
+                        if crypto_prices.get(amount["currency"]):
+                            usd_currency = float(crypto_prices[amount["currency"]]) * float(amount["amount"])
+                            amount["amount"] = usd_currency / float(currency_prices["USD"])
+                            amount["currency"] = base


### PR DESCRIPTION
- adds the frontend logic for getting recent transactions
- adds `/api/recent-transactions` endpoint to Portfolio
    - It accepts a `Recent` header. If the value is `True` only the last 6 transactions will be returned. Otherwise all transactions will be returned
    - each transaction has the following JSON structure:
```json
[
    "someId": {
        "amount": {
            "amount": "Float",
            "currency": "String",
        },
        "date": "yyyy-mm-dd",
        "type": "String"
    }
]
```
closes #237