### PR TITLE
Extend routing in Client

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,6 +3,10 @@ import "./App.css";
 import DashboardPage from "./components/Pages/DashboardPage";
 import ProfilePage from "./components/Pages/ProfilePage";
 import LandingPage from "./components/Pages/LandingPage";
+import PortfolioPage from "./components/Pages/PortfolioPage";
+import CashflowPage from "./components/Pages/CashflowPage";
+import AdvicePage from "./components/Pages/AdvicePage";
+
 import {
   BrowserRouter as Router,
   Route,
@@ -24,8 +28,11 @@ function App() {
         <Route path="/" exact>
           {isAuthenticated ? <Redirect to="/dashboard" /> : <LandingPage />}
         </Route>
-        <Route path="/profile" exact component={ProfilePage} />
         <Route path="/dashboard" exact component={DashboardPage} />
+        <Route path="/profile" exact component={ProfilePage} />
+        <Route path="/portfolio" exact component={PortfolioPage} />
+        <Route path="/cashflow" exact component={CashflowPage} />
+        <Route path="/advice" exact component={AdvicePage} />
       </Switch>
     </Router>
   );

--- a/client/src/components/Other/HeaderComponent.js
+++ b/client/src/components/Other/HeaderComponent.js
@@ -9,6 +9,8 @@ import arrow_down from "../../images/Vector_down.svg";
 import BaseCurrencyDropDownList from "./BaseCurrencyDropDownList";
 import LogOutButton from "../Buttons/LogOutButton";
 
+import { Link } from "react-router-dom";
+
 import { styled } from "@mui/material/styles";
 import Tooltip, { tooltipClasses } from "@mui/material/Tooltip";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
@@ -34,24 +36,16 @@ const Header = ({ baseSymbol, username }) => {
         <div className="borderline" />
         <ul className="menu-rooter">
           <li>
-            <a className="nav-link" href="#">
-              Overview
-            </a>
+            <Link to={"/"}>Overview</Link>
           </li>
           <li>
-            <a className="nav-link" href="#">
-              Portfolio
-            </a>
+            <Link to={"/portfolio"}>Portfolio</Link>
           </li>
           <li>
-            <a className="nav-link" href="#">
-              Cashflow
-            </a>
+            <Link to={"/cashflow"}>Cashflow</Link>
           </li>
           <li>
-            <a className="nav-link" href="#">
-              Advice
-            </a>
+            <Link to={"/advice"}>Advice</Link>
           </li>
         </ul>
       </div>

--- a/client/src/components/Pages/AdvicePage.js
+++ b/client/src/components/Pages/AdvicePage.js
@@ -1,0 +1,26 @@
+import React, { useState, useEffect } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+import { Redirect } from "react-router";
+
+import "../../styles/dashboard.scss";
+import "../../styles/main_content.scss";
+import Loader from "../Other/LoaderComponent";
+
+// Dashboard page to be filled in with user account data
+const AdvicePage = () => {
+  const { isAuthenticated, user, loading } = useAuth0();
+  //   Return this if Auth0 is still loading. Can be replaced with an animation in the future
+  if (loading) {
+    return Loader();
+  }
+
+  return (
+    isAuthenticated && (
+      <div>
+        <h2>This is the advice page</h2>
+      </div>
+    )
+  );
+};
+
+export default AdvicePage;

--- a/client/src/components/Pages/CashflowPage.js
+++ b/client/src/components/Pages/CashflowPage.js
@@ -1,0 +1,26 @@
+import React, { useState, useEffect } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+import { Redirect } from "react-router";
+
+import "../../styles/dashboard.scss";
+import "../../styles/main_content.scss";
+import Loader from "../Other/LoaderComponent";
+
+// Dashboard page to be filled in with user account data
+const CashflowPage = () => {
+  const { isAuthenticated, user, loading } = useAuth0();
+  //   Return this if Auth0 is still loading. Can be replaced with an animation in the future
+  if (loading) {
+    return Loader();
+  }
+
+  return (
+    isAuthenticated && (
+      <div>
+        <h2>This is the cashflow page</h2>
+      </div>
+    )
+  );
+};
+
+export default CashflowPage;

--- a/client/src/components/Pages/DashboardPage.js
+++ b/client/src/components/Pages/DashboardPage.js
@@ -36,36 +36,62 @@ const DashboardPage = () => {
 
   useEffect(() => {
     const getUserData = async () => {
-      const token = await getAccessTokenSilently();
-      const response = await getUser(token);
-      setBase(response.base_currency);
+      if (window.sessionStorage.getItem("base")) {
+        setBase(JSON.parse(window.sessionStorage.getItem("base")));
+      } else {
+        const token = await getAccessTokenSilently();
+        const response = await getUser(token);
+        window.sessionStorage.setItem(
+          "base",
+          JSON.stringify(response.base_currency)
+        );
+        setBase(response.base_currency);
+      }
     };
     getUserData();
   }, []);
 
   const getData = async () => {
     setLoading(true);
-    const token = await getAccessTokenSilently();
+    if (
+      window.sessionStorage.getItem("total") &&
+      window.sessionStorage.getItem("assets") &&
+      window.sessionStorage.getItem("recentTransactions")
+    ) {
+      console.log("are ve");
+      setTotal(JSON.parse(window.sessionStorage.getItem("total")));
+      setGroups(JSON.parse(window.sessionStorage.getItem("assets")));
+      setRecentTransactions(
+        JSON.parse(window.sessionStorage.getItem("recentTransactions"))
+      );
+    } else {
+      const token = await getAccessTokenSilently();
 
-    // fetch all of the data in parllel using Promise.all
-    await Promise.all([
-      (async () => {
-        const assets = await getAssets(token);
-        const total = assets.total;
-        delete assets.total;
+      // fetch all of the data in parllel using Promise.all
+      await Promise.all([
+        (async () => {
+          const assets = await getAssets(token);
+          const total = assets.total;
+          delete assets.total;
 
-        setTotal(total);
-        setGroups(assets);
-      })(),
-      (async () => {
-        const transactions = await getRecentTransactions(token);
-        setRecentTransactions(transactions);
-      })(),
-    ]);
+          window.sessionStorage.setItem("total", JSON.stringify(total));
+          window.sessionStorage.setItem("assets", JSON.stringify(assets));
+          setTotal(total);
+          setGroups(assets);
+        })(),
+        (async () => {
+          const transactions = await getRecentTransactions(token);
+          window.sessionStorage.setItem(
+            "recentTransactions",
+            JSON.stringify(transactions)
+          );
+          setRecentTransactions(transactions);
+        })(),
+      ]);
+    }
 
     setLoading(false);
   };
-
   const getAccountTransactions = async (provider, account) => {
     setLoading(true);
     const token = await getAccessTokenSilently();

--- a/client/src/components/Pages/DashboardPage.js
+++ b/client/src/components/Pages/DashboardPage.js
@@ -40,6 +40,7 @@ const DashboardPage = () => {
       const response = await getUser(token);
 
       setBase(response.base_currency);
+      window.sessionStorage.clear();
     };
     getUserData();
   }, []);

--- a/client/src/components/Pages/DashboardPage.js
+++ b/client/src/components/Pages/DashboardPage.js
@@ -36,17 +36,10 @@ const DashboardPage = () => {
 
   useEffect(() => {
     const getUserData = async () => {
-      if (window.sessionStorage.getItem("base")) {
-        setBase(JSON.parse(window.sessionStorage.getItem("base")));
-      } else {
-        const token = await getAccessTokenSilently();
-        const response = await getUser(token);
-        window.sessionStorage.setItem(
-          "base",
-          JSON.stringify(response.base_currency)
-        );
-        setBase(response.base_currency);
-      }
+      const token = await getAccessTokenSilently();
+      const response = await getUser(token);
+
+      setBase(response.base_currency);
     };
     getUserData();
   }, []);
@@ -56,9 +49,9 @@ const DashboardPage = () => {
     if (
       window.sessionStorage.getItem("total") &&
       window.sessionStorage.getItem("assets") &&
-      window.sessionStorage.getItem("recentTransactions")
+      window.sessionStorage.getItem("recentTransactions") &&
+      window.sessionStorage.getItem("base") === base
     ) {
-      console.log("are ve");
       setTotal(JSON.parse(window.sessionStorage.getItem("total")));
       setGroups(JSON.parse(window.sessionStorage.getItem("assets")));
       setRecentTransactions(
@@ -66,7 +59,7 @@ const DashboardPage = () => {
       );
     } else {
       const token = await getAccessTokenSilently();
-
+      window.sessionStorage.setItem("base", base);
       // fetch all of the data in parllel using Promise.all
       await Promise.all([
         (async () => {

--- a/client/src/components/Pages/PortfolioPage.js
+++ b/client/src/components/Pages/PortfolioPage.js
@@ -1,0 +1,27 @@
+import React, { useState, useEffect } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+import { Redirect } from "react-router";
+
+import "../../styles/dashboard.scss";
+import "../../styles/main_content.scss";
+import Loader from "../Other/LoaderComponent";
+
+// Dashboard page to be filled in with user account data
+const PortfolioPage = () => {
+  const { isAuthenticated, user, loading } = useAuth0();
+  //   Return this if Auth0 is still loading. Can be replaced with an animation in the future
+
+  if (loading) {
+    return Loader();
+  }
+
+  return (
+    isAuthenticated && (
+      <div>
+        <h2>This is the portfolio page</h2>
+      </div>
+    )
+  );
+};
+
+export default PortfolioPage;


### PR DESCRIPTION
- adds routing between the main pages of the app
- adds caching to the data fetched in DashboardPage to avoid the repetition of requests when the user navigates from another page back to the dashboard(the caching is done using `window.sessionStorage`)

closes #258 